### PR TITLE
Implement RLockAll()

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,42 +8,59 @@
 <a href="https://coveralls.io/github/kelindar/smutex"><img src="https://coveralls.io/repos/github/kelindar/smutex/badge.svg" alt="Coverage"></a>
 </p>
 
-
 # Sharded Mutex in Go
 
-This package contains a sharded mutex which *should* do better than a traditional `sync.RWMutex` in certain cases where you want to protect resources that are well distributed. For example, you can use this to protect a hash table as keys have no relation to each other. That being said, for the hash table use-case you should probably use `sync.Map`.
+This package contains a sharded mutex which _should_ do better than a traditional `sync.RWMutex` in certain cases where you want to protect resources that are well distributed. For example, you can use this to protect a hash table as keys have no relation to each other. That being said, for the hash table use-case you should probably use `sync.Map`.
 
-The `SMutex128` works by actually creating 128 `sync.RWMutex` and providing `Lock()`, `Unlock()` methods that accept a `shard` argument. A shard argument can overflow the actual number of shards, and mutex uses a modulus operation to wrap around.
-
+The `SMutex` works by actually creating an array of `sync.RWMutex` and providing `Lock()`, `Unlock()` methods that accept a `shard` argument. A shard argument can overflow the actual number of shards, and mutex uses a modulus operation to wrap around.
 
 ```go
+// Create a new sharded mutex with 128 shards
+mu := smutex.New(128)
+
 // Acquire a write lock for shard #1
 mu.Lock(1)
 resourceInShard1 = "hello"
 
-// Release the lock in shard #1
+// Release the lock for shard #1
 mu.Unlock(1)
+```
+
+## Global Read Lock
+
+In addition to the ability to lock individual shards for both read and write using `Lock(shard)`, `Unlock(shard)`, `RLock(shard)` and `RUnlock(shard)`, this library also provides the ability to lock all shards for read at once, creating a priority lock that waits for all writers to finish prior to acquiring this.
+
+```go
+// Create a new sharded mutex with 128 shards
+mu := smutex.New(128)
+
+// Acquire a global lock on all shards
+mu.RLockAll()
+
+// Unlock shards one by one
+for i := 0; i < shards; i++ {
+    m.mu.RUnlock(uint(i))
+}
 ```
 
 ## Caveats
 
-* Sharded mutex would use significantly more memory and needs to be used with care. In fact, the 128 shard implementation would use 8192 bytes of memory, and would ideally be living in L1. The reason being is that the current implementation pads mutexes so only one of them is present in a cache line, to prevent false sharing. 
-* Do benchmark on your own use-case if you want to use this library, I found that in certain cases the current implementation does not perform very well, but need to investigate a bit more. It's usually on-par with the `RWMutex` at the very least.
+Do benchmark on your own use-case if you want to use this library, I found that in certain cases the current implementation does not perform very well, but need to investigate a bit more.
 
 ## Benchmarks
 
 ```
 cpu: Intel(R) Core(TM) i7-9700K CPU @ 3.60GHz
-BenchmarkLock/single/procs=64-8                    64495            184600 ns/op
-BenchmarkLock/single/procs=256-8                   75350            161236 ns/op
-BenchmarkLock/single/procs=1024-8                  85765            161982 ns/op
-BenchmarkLock/single/procs=4096-8                  86328            160925 ns/op
-BenchmarkLock/single/procs=16384-8                 85803            153741 ns/op
-BenchmarkLock/single/procs=65536-8                 85806            152246 ns/op
-BenchmarkLock/sharded/procs=64-8                  342633             35435 ns/op
-BenchmarkLock/sharded/procs=256-8                 390313             30818 ns/op
-BenchmarkLock/sharded/procs=1024-8                416959             30493 ns/op
-BenchmarkLock/sharded/procs=4096-8                443528             30246 ns/op
-BenchmarkLock/sharded/procs=16384-8               427383             30118 ns/op
-BenchmarkLock/sharded/procs=65536-8               451612             30922 ns/op
+BenchmarkLock/single/procs=64-8                     6338            181495 ns/op
+BenchmarkLock/single/procs=256-8                    8844            165454 ns/op
+BenchmarkLock/single/procs=1024-8                   8330            144282 ns/op
+BenchmarkLock/single/procs=4096-8                   7188            142298 ns/op
+BenchmarkLock/single/procs=16384-8                  8124            185415 ns/op
+BenchmarkLock/single/procs=65536-8                  7146            144743 ns/op
+BenchmarkLock/sharded/procs=64-8                   21411             53848 ns/op
+BenchmarkLock/sharded/procs=256-8                  24202             50499 ns/op
+BenchmarkLock/sharded/procs=1024-8                 26904             48445 ns/op
+BenchmarkLock/sharded/procs=4096-8                 27116             47752 ns/op
+BenchmarkLock/sharded/procs=16384-8                26959             50244 ns/op
+BenchmarkLock/sharded/procs=65536-8                25498             48610 ns/op
 ```

--- a/smutex.go
+++ b/smutex.go
@@ -3,38 +3,124 @@
 
 package smutex
 
-import "sync"
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+)
 
-const shards = 128
+type shard struct {
+	sync.RWMutex
+	sync.Cond
+}
 
 // SMutex128 represents a sharded RWMutex that supports finer-granularity concurrency
 // contron hence reducing potential contention.
-type SMutex128 struct {
-	mu [shards]struct {
-		sync.RWMutex
-		_ [40]byte // Padding to prevent false sharing
+type SMutex struct {
+	state  uint64
+	shards uint
+	mu     []shard
+}
+
+// New creates a new sharded mutex with a specified number of shards
+func New(shards uint) *SMutex {
+	mutex := &SMutex{
+		shards: shards,
+		mu:     make([]shard, shards),
 	}
+
+	// Wire up conditional variables to mutexes
+	for i := 0; i < int(shards); i++ {
+		mutex.mu[i].Cond.L = &mutex.mu[i].RWMutex
+	}
+	return mutex
 }
 
 // Lock locks rw for writing. If the lock is already locked for reading or writing,
 // then Lock blocks until the lock is available.
-func (rw *SMutex128) Lock(shard uint) {
-	rw.mu[shard%shards].Lock()
+func (rw *SMutex) Lock(shard uint) {
+	mx := &rw.mu[shard%rw.shards]
+
+	// Acquire write lock. If there's a priority reader waiting, unlock and wait on
+	// until the associated conditional variable has a broadcast.
+	mx.Lock()
+	for {
+		state := atomic.LoadUint64(&rw.state)
+		readers := state >> 32
+		writers := (state & 0xffffffff) + 1
+		if readers > 0 {
+			mx.Wait()
+		}
+
+		// Increment writer count now that we've acquired the lock
+		if atomic.CompareAndSwapUint64(&rw.state, state, readers<<32+writers) {
+			return // lock acquired
+		}
+	}
 }
 
 // Unlock unlocks rw for writing. It is a run-time error if rw is not locked for
 // writing on entry to Unlock.
-func (rw *SMutex128) Unlock(shard uint) {
-	rw.mu[shard%shards].Unlock()
+func (rw *SMutex) Unlock(shard uint) {
+	rw.mu[shard%rw.shards].Unlock()
+	for { // decrement the writer count
+		state := atomic.LoadUint64(&rw.state)
+		readers := state >> 32
+		writers := (state & 0xffffffff) - 1
+		if atomic.CompareAndSwapUint64(&rw.state, state, (readers<<32)+writers) {
+			break
+		}
+
+		runtime.Gosched()
+	}
+}
+
+// RLockAll locks rw for reading on all shards, the unlock needs to still happen
+// shard by shard. It ensures that all writers have finished their work before
+// acquiring the lock, in order to avoid any potential deadlocks.
+func (rw *SMutex) RLockAll() {
+	for { // increment global reader count
+		state := atomic.LoadUint64(&rw.state)
+		readers := (state >> 32) + 1
+		writers := state & 0xffffffff
+		if atomic.CompareAndSwapUint64(&rw.state, state, (readers<<32)+writers) {
+			break // reader set to 1
+		}
+
+		if writers > 0 {
+			runtime.Gosched()
+		}
+	}
+
+	// Acquire read locks for every single shard
+	for i := uint(0); i < rw.shards; i++ {
+		rw.mu[i].RLock()
+	}
+
+	for { // decrement global reader count
+		state := atomic.LoadUint64(&rw.state)
+		readers := (state >> 32) - 1
+		writers := state & 0xffffffff
+		if atomic.CompareAndSwapUint64(&rw.state, state, (readers<<32)+writers) {
+			break
+		}
+
+		runtime.Gosched()
+	}
+
+	// Wake up all writers and let them wait on their lock
+	for i := uint(0); i < rw.shards; i++ {
+		rw.mu[i].Broadcast()
+	}
 }
 
 // RLock locks rw for reading. It should not be used for recursive read locking; a
 // blocked Lock call excludes new readers from acquiring the lock.
-func (rw *SMutex128) RLock(shard uint) {
-	rw.mu[shard%shards].RLock()
+func (rw *SMutex) RLock(shard uint) {
+	rw.mu[shard%rw.shards].RLock()
 }
 
 // RUnlock undoes a single RLock call and does not affect other simultaneous readers.
-func (rw *SMutex128) RUnlock(shard uint) {
-	rw.mu[shard%shards].RUnlock()
+func (rw *SMutex) RUnlock(shard uint) {
+	rw.mu[shard%rw.shards].RUnlock()
 }

--- a/smutex_test.go
+++ b/smutex_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -122,12 +123,16 @@ func TestRLockAll(t *testing.T) {
 	wg.Add(512)
 	for i := 0; i < 512; i++ {
 		go func() {
-			m.Set(rand.Int63n(shards), "ok")
+			for i := 0; i < 100; i++ {
+				time.Sleep(1 * time.Millisecond)
+				m.Set(rand.Int63n(shards), "ok")
+			}
 			wg.Done()
 		}()
 	}
 
 	m.mu.RLockAll()
+	time.Sleep(10 * time.Millisecond)
 
 	// Unlock all
 	for i := 0; i < shards; i++ {


### PR DESCRIPTION
This PR implements `RLockAll()` that acquires a priority read lock on all shards.